### PR TITLE
use `nvim_buf_set_lines` instead of `append()`

### DIFF
--- a/lua/md-to-html.lua
+++ b/lua/md-to-html.lua
@@ -39,8 +39,7 @@ local function md_to_html()
   local fixed_html_content = html_content:gsub("[\n\r]", "")
 
   -- Wipe current buffer
-  api.nvim_buf_set_lines(0, 0, -1, false, {})
-  vim.cmd('call append(0, "' .. fixed_html_content .. '")')
+  api.nvim_buf_set_lines(0, 0, -1, false, {fixed_html_content})
 end
 
 return {


### PR DESCRIPTION
I had an error when running when 

```
fixed_html_content = "<h2>Testing with threads</h2><p>Question: Is it possible to spawn multiple threadsin neovim to read files and then concatenate allthe result and present them to the user?</p><p>```luaprint(vim.inspect(vim.version()))``````output<a href="09/16/22 13:59:02">4</a>{  api<em>compatible = 0,  api</em>level = 10,  api_prerelease = true,  major = 0,  minor = 8,  patch = 0,  prerelease = true}```</p>"
```

at line 43 in md-to-html.lua when calling vim's `append` .
